### PR TITLE
fix composer install fails on fresh install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache
+FROM php:8.0.2-apache
 
 RUN apt update
 RUN apt install -y zip git libicu-dev libmariadb-dev libsqlite3-dev build-essential libzip-dev libfreetype6-dev libjpeg62-turbo-dev libpng-dev libpq-dev
@@ -31,7 +31,7 @@ RUN docker-php-ext-enable apcu
 RUN docker-php-ext-configure pdo_pgsql 
 RUN docker-php-ext-install -j$(nproc) pdo_pgsql
 RUN docker-php-ext-enable pdo_pgsql
-           
+
 # run the dependancy installation
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 


### PR DESCRIPTION
On fresh install (docker-compose from fresh git clone)

` 
=> ERROR [31/37] RUN composer install                                                                                                       1.4s 
------
 > [31/37] RUN composer install:
#0 1.361 Installing dependencies from lock file (including require-dev)
#0 1.371 Verifying lock file contents can be installed on current platform.
#0 1.384 Your lock file does not contain a compatible set of packages. Please run composer update.
#0 1.384
#0 1.384   Problem 1
#0 1.384     - psr/simple-cache is locked to version 2.0.0 and an update of this package was not requested.
#0 1.384     - psr/simple-cache 2.0.0 requires php >=8.0.0 -> your php version (7.4.33) does not satisfy that requirement.
#0 1.384   Problem 2
#0 1.384     - ramsey/uuid is locked to version 4.4.0 and an update of this package was not requested.
#0 1.384     - ramsey/uuid 4.4.0 requires php ^8.0 -> your php version (7.4.33) does not satisfy that requirement.
#0 1.384   Problem 3
#0 1.384     - symfony/deprecation-contracts is locked to version v3.0.2 and an update of this package was not requested.
#0 1.384     - symfony/deprecation-contracts v3.0.2 requires php >=8.0.2 -> your php version (7.4.33) does not satisfy that requirement.
#0 1.384   Problem 4
#0 1.384     - symfony/deprecation-contracts v3.0.2 requires php >=8.0.2 -> your php version (7.4.33) does not satisfy that requirement.
#0 1.384     - guzzlehttp/guzzle 7.4.5 requires symfony/deprecation-contracts ^2.2 || ^3.0 -> satisfiable by symfony/deprecation-contracts[v3.0.2].
#0 1.384     - guzzlehttp/guzzle is locked to version 7.4.5 and an update of this package was not requested.
#0 1.384
------
failed to solve: executor failed running [/bin/sh -c composer install]: exit code: 2
`
